### PR TITLE
fix(host-detection): prefer user-defined NEXTAUTH_URL over automatic "forwardedHost" in Vercel environment

### DIFF
--- a/packages/next-auth/src/next/utils.ts
+++ b/packages/next-auth/src/next/utils.ts
@@ -16,8 +16,11 @@ export function setCookie(res, cookie: Cookie) {
 
 /** Extract the host from the environment */
 export function detectHost(forwardedHost: any) {
+  /* If the user has explicitly set canonical URL using NEXTAUTH_URL,
+   we respect that setting. */
+  if (process.env.NEXTAUTH_URL) return process.env.NEXTAUTH_URL
   // If we detect a Vercel environment, we can trust the host
   if (process.env.VERCEL) return forwardedHost
-  // If `NEXTAUTH_URL` is `undefined` we fall back to "http://localhost:3000"
-  return process.env.NEXTAUTH_URL
+  // Fallback to "http://localhost:3000"
+  return undefined
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
This PR affects behavior that can only be observed in Vercel deployments.

The commit reverts behavior introduced by https://github.com/nextauthjs/next-auth/pull/3649, where the user-defined environment variable `NEXTAUTH_URL` is ignored in favor of the value of `x-forwarded-host`.

## ☕️ Reasoning
If a user deliberately sets a `NEXTAUTH_URL` environment variable, it means they wanted Vercel to use this as the canonical URL. next-auth should consider this deliberately defined value first and then fallback to automatic behavior otherwise. The current behavior, which is to use `x-forwarded-host` when available and fallback to user-defined `NEXTAUTH_URL` (on top of being surprising and not consistent with the [documentation](https://next-auth.js.org/configuration/options#nextauth_url)) breaks in multiple situations, including our current staging environment:

1. If a proxy sits between the user and the deployment on Vercel, wherein the actual site host and Vercel's deployment URL do no match, next-auth will end up using Vercel's deployment URL. For example, we have nginx listening at example.dev and our staging deployment at staging.example.com. Even though NEXTAUTH_URL=example.dev, next-auth sets `redirect_uri` to staging.example.com.
2. If you are using a Preview deployment, e.g. example.vercel.app, the current behavior is to set `redirect_uri=<preview_url>` which is practically guaranteed to not be whitelisted by your provider (since you can't know the auto-generated preview URL ahead of time).

## 🧢 Checklist

- [X] ~Documentation~ consistent with existing
- [X] Tests
- [X] Ready to be merged (behavior tested locally)